### PR TITLE
Fix vue-draggable registration

### DIFF
--- a/js/valve-control.js
+++ b/js/valve-control.js
@@ -203,6 +203,6 @@ createApp({
   </div>
   `,
   components: {
-    draggable: window.vuedraggable,
+    draggable: window.vuedraggable || window.VueDraggableNext,
   },
 }).mount('#app');


### PR DESCRIPTION
## Summary
- ensure valve-control.js can find draggable component if CDN exposes `VueDraggableNext`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_686a55044e8c832ab0d4418e75a230e9